### PR TITLE
fix-truncate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## Dradis Framework 3.6 (March XX, 2017) ##
+## Dradis Framework 3.7 (XXX, 2017) ##
+
+*   Don't lose :plugin and :plugin_id from ContentService#create_issue due to
+    excessive input length.
+
+## Dradis Framework 3.6 (April 6, 2017) ##
 
 *   Split the ContentService into multiple modules.
 

--- a/lib/dradis/plugins/content_service/core.rb
+++ b/lib/dradis/plugins/content_service/core.rb
@@ -40,7 +40,7 @@ module Dradis::Plugins::ContentService
       else
         # bail
         msg = "#[Title]#\n#{msg}\n\n"
-        msg << "#[Description]#\nbc. #{issue.errors.inspect}\n\n"
+        msg << "#[Description]#\nbc. #{model.errors.inspect}\n\n"
         model.send("#{field}=", msg)
       end
       if model.valid?

--- a/lib/dradis/plugins/content_service/core.rb
+++ b/lib/dradis/plugins/content_service/core.rb
@@ -28,6 +28,7 @@ module Dradis::Plugins::ContentService
       field = args[:field]
       text  = args[:text]
       msg   = args[:msg]
+      tail  = "..." + args[:tail].to_s
 
       logger.error{ "Trying to rescue from a :length error" }
 
@@ -36,7 +37,7 @@ module Dradis::Plugins::ContentService
         msg = "#[Title]#\nTruncation warning!\n\n"
         msg << "#[Error]#\np(alert alert-error). The plugin tried to store content that was too big for the DB. Review the source to ensure no important data was lost.\n\n"
         msg << text
-        model.send("#{field}=", msg.truncate(65300))
+        model.send("#{field}=", msg.truncate(65300, omission: tail))
       else
         # bail
         msg = "#[Title]#\n#{msg}\n\n"

--- a/lib/dradis/plugins/content_service/issues.rb
+++ b/lib/dradis/plugins/content_service/issues.rb
@@ -19,8 +19,10 @@ module Dradis::Plugins::ContentService
       return issue_cache[cache_key] if issue_cache.key?(cache_key)
 
       # we inject the source Plugin and unique ID into the issue's text
-      text << "\n\n#[plugin]#\n#{uuid[0]}\n"
-      text << "\n\n#[plugin_id]#\n#{uuid[1]}\n"
+      plugin_details =
+        "\n\n#[plugin]#\n#{uuid[0]}\n" \
+        "\n\n#[plugin_id]#\n#{uuid[1]}\n"
+      text << plugin_details
 
       issue = Issue.new(text: text) do |i|
         i.author   = default_author
@@ -37,6 +39,10 @@ module Dradis::Plugins::ContentService
           text: text,
           msg: 'Error in create_issue()'
         )
+
+        # Re-inject the plugin details
+        issue.text[-(plugin_details.length)..-1] = plugin_details
+        issue.save
       end
 
       issue_cache.store(cache_key, issue)

--- a/lib/dradis/plugins/content_service/issues.rb
+++ b/lib/dradis/plugins/content_service/issues.rb
@@ -37,12 +37,9 @@ module Dradis::Plugins::ContentService
           model: issue,
           field: :text,
           text: text,
-          msg: 'Error in create_issue()'
+          msg: 'Error in create_issue()',
+          tail: plugin_details
         )
-
-        # Re-inject the plugin details
-        issue.text[-(plugin_details.length)..-1] = plugin_details
-        issue.save
       end
 
       issue_cache.store(cache_key, issue)

--- a/lib/dradis/plugins/gem_version.rb
+++ b/lib/dradis/plugins/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
     module VERSION
       MAJOR = 3
       MINOR = 6
-      TINY  = 0
+      TINY  = 1
       PRE   = nil
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")


### PR DESCRIPTION
### Spec

When importing an issue with text that exceeds the possible length, the app tries to truncate it. This results in the plugin details to be truncated too.

**Proposed solution**

Re-insert the plugin details after truncation.


### How to test

1. Install the Netsparker plugin in your Gemfile. https://github.com/dradis/dradis-netsparker
2. Get a netsparker XML.
3. Go to "Upload output from tool in the app" in Dradis
4. Upload the downloaded XML using the Netsparker plugin
5. Assert that there are no errors and the upload is successful.