### PR TITLE
a default logger to stdout that doesn't close stdout

### DIFF
--- a/lib/dradis/plugins/thor_helper.rb
+++ b/lib/dradis/plugins/thor_helper.rb
@@ -2,6 +2,17 @@ module Dradis
   module Plugins
     # Helper methods for plugin Thor tasks
     module ThorHelper
+      # A default logger to STDOUT that doesn't close, even if #close is called
+      class DefaultLogger < Logger
+        def initialize
+          STDOUT.sync = true
+          super(STDOUT)
+          self.level = Logger::DEBUG
+        end
+
+        def close; end
+      end
+
       attr_accessor :task_options, :logger
 
       def detect_and_set_project_scope
@@ -13,16 +24,7 @@ module Dradis
       end
 
       def logger
-        @logger ||= default_logger
-      end
-
-
-      private
-      def default_logger
-        STDOUT.sync   = true
-        logger        = Logger.new(STDOUT)
-        logger.level  = Logger::DEBUG
-        logger
+        @logger ||= DefaultLogger.new
       end
     end
   end


### PR DESCRIPTION
When using the logger in plugins, the default logger logs to STDOUT.
But in the plugin thor tasks, sometimes we close the logger.
This means that STDOUT is closed.
Then if the task tries to use `puts` or `print` an error will be raised.
Here we try to fix the default logger, so it doesn't close STDOUT even if `#close` is called on it.