### PR TITLE
Use Node content library for properties

### DIFF
--- a/lib/dradis/plugins/content_service/properties.rb
+++ b/lib/dradis/plugins/content_service/properties.rb
@@ -3,18 +3,7 @@ module Dradis::Plugins::ContentService
     extend ActiveSupport::Concern
 
     def all_properties
-      # TODO: once Report Content is out, we need to load the properties from
-      # Node.content_library and also take into account project scoping.
-      Note.
-        where(category_id: legacy_report_properties_category).
-        limit(1).
-        first.
-        try(:fields) || {}
-    end
-
-    private
-    def legacy_report_properties_category
-      @legacy_report_properties_category ||= Category.find_by_name(Dradis::Pro::Plugins::Word::Engine.settings.category_properties)
+      Node.content_library.properties
     end
   end
 end


### PR DESCRIPTION
For the report content feature, we're phasing out the old style of document properties.