### PR TITLE
include legacy notes

### DIFF
--- a/lib/dradis/plugins/content_service/notes.rb
+++ b/lib/dradis/plugins/content_service/notes.rb
@@ -3,7 +3,12 @@ module Dradis::Plugins::ContentService
     extend ActiveSupport::Concern
 
     def all_notes
-      Note.where(category: Category.report)
+      Note.where(
+        category: [
+          Category.report,
+          Dradis::Pro::Plugins::Word::Engine.settings.category_report
+        ]
+      )
     end
 
     def create_note(args={})


### PR DESCRIPTION
### Spec

We are pausing the  content block part in report content.
When we retrieve the notes to be included using `dradis-plugins#content-service`, old style notes should be included.

**Proposed solution**
Check this method: https://github.com/dradis/dradis-plugins/blob/develop/lib/dradis/plugins/content_service/notes.rb#L5
Also include category: `Dradis::Pro::Plugins::Word::Engine.settings.category_report`


### How to test
- Export a word project with old style content notes.
- Notes should be included in the report.

trello: https://trello.com/c/fdYkPEvC/396-in-dradis-plugin-contentserviceallnotes-should-find-the-old-style-notes