### PR TITLE
Content Blocks import

### DIFF
--- a/lib/dradis/plugins/content_service/content_blocks.rb
+++ b/lib/dradis/plugins/content_service/content_blocks.rb
@@ -1,0 +1,44 @@
+module Dradis::Plugins::ContentService
+  module ContentBlocks
+    extend ActiveSupport::Concern
+
+    def all_content_blocks
+      ContentBlock.where(project_id: project.id)
+    end
+
+    def create_content_block(args={})
+      name    = args.fetch(:name, default_content_block_name)
+      user_id = args.fetch(:user_id)
+      content = args.fetch(:content, default_content_block_content)
+
+      content_block = ContentBlock.new(
+        content: content,
+        name: name,
+        project_id: project.id,
+        user_id: user_id
+      )
+
+      if content_block.valid?
+        content_block.save
+      else
+        try_rescue_from_length_validation(
+          model: content_block,
+          field: :content,
+          text: content,
+          msg: 'Error in create_content_block()',
+          tail: plugin_details
+        )
+      end
+    end
+
+    private
+
+    def default_content_block_content
+      "create_content_block() invoked by #{plugin} without a :content parameter"
+    end
+
+    def default_content_block_name
+      "create_content_block() invoked by #{plugin} without a :name parameter"
+    end
+  end
+end

--- a/lib/dradis/plugins/content_service/nodes.rb
+++ b/lib/dradis/plugins/content_service/nodes.rb
@@ -74,7 +74,7 @@ module Dradis::Plugins::ContentService
     #
     # Returns and Array with a unique collection of Nodes.
     def nodes_from_properties
-      Node.user_nodes.where('properties IS NOT NULL AND properties != \'{}\'')
+      Node.user_nodes.where("type_id <> #{Node::Types::CONTENTLIB} AND properties IS NOT NULL AND properties != '{}'")
     end
   end
 end

--- a/lib/dradis/plugins/content_service/nodes.rb
+++ b/lib/dradis/plugins/content_service/nodes.rb
@@ -74,7 +74,7 @@ module Dradis::Plugins::ContentService
     #
     # Returns and Array with a unique collection of Nodes.
     def nodes_from_properties
-      Node.user_nodes.where("type_id <> #{Node::Types::CONTENTLIB} AND properties IS NOT NULL AND properties != '{}'")
+      Node.user_nodes.where('properties IS NOT NULL AND properties != \'{}\'')
     end
   end
 end

--- a/lib/dradis/plugins/upload/importer.rb
+++ b/lib/dradis/plugins/upload/importer.rb
@@ -5,7 +5,15 @@ module Dradis
   module Plugins
     module Upload
       class Importer
-        attr_accessor :content_service, :logger, :options, :plugin, :project, :template_service
+        attr_accessor(
+          :content_service,
+          :current_user_id,
+          :logger,
+          :options,
+          :plugin,
+          :project,
+          :template_service
+        )
 
         def initialize(args={})
           @options = args
@@ -13,6 +21,7 @@ module Dradis
           @logger  = args.fetch(:logger, Rails.logger)
           @plugin  = args[:plugin] || default_plugin
           @project = args.key?(:project_id) ? Project.find(args[:project_id]) : nil
+          @default_user_id = args[:default_user_id] || -1
 
           @content_service  = args.fetch(:content_service, default_content_service)
           @template_service = args.fetch(:template_service, default_template_service)

--- a/lib/dradis/plugins/upload/importer.rb
+++ b/lib/dradis/plugins/upload/importer.rb
@@ -7,7 +7,7 @@ module Dradis
       class Importer
         attr_accessor(
           :content_service,
-          :current_user_id,
+          :default_user_id,
           :logger,
           :options,
           :plugin,


### PR DESCRIPTION
- Added method `create_content_blocks` to content service 
- Add the ability to pass a `default_user_id` to the importer that you can use to fill in the required user associations when importing data. 