### PR TITLE
Content blocks alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.10 (January, 2018) ##
+
+*  Default title sorting for content blocks
+
 ## Dradis Framework 3.9 (January, 2018) ##
 
 *  No changes

--- a/lib/dradis/plugins/content_service/content_blocks.rb
+++ b/lib/dradis/plugins/content_service/content_blocks.rb
@@ -3,7 +3,7 @@ module Dradis::Plugins::ContentService
     extend ActiveSupport::Concern
 
     def all_content_blocks
-      ContentBlock.where(project_id: project.id).sort_by { |x| x.title.downcase }
+      ContentBlock.where(project_id: project.id).sort_by { |cb| cb.title.downcase }
     end
 
     def create_content_block(args={})

--- a/lib/dradis/plugins/content_service/content_blocks.rb
+++ b/lib/dradis/plugins/content_service/content_blocks.rb
@@ -3,7 +3,7 @@ module Dradis::Plugins::ContentService
     extend ActiveSupport::Concern
 
     def all_content_blocks
-      ContentBlock.where(project_id: project.id)
+      ContentBlock.where(project_id: project.id).sort_by { |x| x.title.downcase }
     end
 
     def create_content_block(args={})

--- a/lib/dradis/plugins/gem_version.rb
+++ b/lib/dradis/plugins/gem_version.rb
@@ -7,7 +7,7 @@ module Dradis
 
     module VERSION
       MAJOR = 3
-      MINOR = 9
+      MINOR = 10
       TINY  = 0
       PRE   = nil
 


### PR DESCRIPTION
The `#all_content_blocks` method will now return alphabetically ordered Content Blocks by default.