### PR TITLE
Update the ContentService to go through the :project to access content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Dradis Framework 3.10 (January, 2018) ##
+## Dradis Framework 3.10 (###) ##
 
 *  Default title sorting for content blocks
+*  Avoid requiring the caller to use `set_project_scope`
 
 ## Dradis Framework 3.9 (January, 2018) ##
 

--- a/lib/dradis/plugins/content_service/issues.rb
+++ b/lib/dradis/plugins/content_service/issues.rb
@@ -3,7 +3,7 @@ module Dradis::Plugins::ContentService
     extend ActiveSupport::Concern
 
     def all_issues
-      Issue.where(category_id: default_issue_category.id)
+      project.issues.where(category_id: default_issue_category.id)
     end
 
     def create_issue(args={})
@@ -26,7 +26,7 @@ module Dradis::Plugins::ContentService
 
       issue = Issue.new(text: text) do |i|
         i.author   = default_author
-        i.node     = issue_library
+        i.node     = project.issue_library
         i.category = default_issue_category
       end
 
@@ -90,10 +90,5 @@ module Dradis::Plugins::ContentService
     def default_issue_text
       "create_issue() invoked by #{plugin} without a :text parameter"
     end
-
-    def issue_library
-      @issue_library ||= Node.issue_library
-    end
-
   end
 end

--- a/lib/dradis/plugins/content_service/nodes.rb
+++ b/lib/dradis/plugins/content_service/nodes.rb
@@ -44,7 +44,7 @@ module Dradis::Plugins::ContentService
     end
 
     def default_node_parent
-      @default_parent_node ||= Node.plugin_parent_node
+      @default_parent_node ||= project.plugin_parent_node
     end
 
     def default_node_type
@@ -74,7 +74,7 @@ module Dradis::Plugins::ContentService
     #
     # Returns and Array with a unique collection of Nodes.
     def nodes_from_properties
-      Node.user_nodes.where('properties IS NOT NULL AND properties != \'{}\'')
+      project.nodes.user_nodes.where('properties IS NOT NULL AND properties != \'{}\'')
     end
   end
 end

--- a/lib/dradis/plugins/content_service/notes.rb
+++ b/lib/dradis/plugins/content_service/notes.rb
@@ -3,7 +3,7 @@ module Dradis::Plugins::ContentService
     extend ActiveSupport::Concern
 
     def all_notes
-      Note.where(category: Category.report)
+      project.notes.where(category: Category.report)
     end
 
     def create_note(args={})

--- a/lib/dradis/plugins/content_service/properties.rb
+++ b/lib/dradis/plugins/content_service/properties.rb
@@ -3,7 +3,7 @@ module Dradis::Plugins::ContentService
     extend ActiveSupport::Concern
 
     def all_properties
-      Node.content_library.properties
+      project.content_library.properties
     end
   end
 end


### PR DESCRIPTION
Instead of relying on `set_project_scope` elsewhere, we're going to fetch the records using the right project-based relationships.