### PR TITLE
Add default project to task options

### DIFF
--- a/lib/dradis/plugins/thor_helper.rb
+++ b/lib/dradis/plugins/thor_helper.rb
@@ -5,7 +5,7 @@ module Dradis
       attr_accessor :task_options, :logger
 
       def detect_and_set_project_scope
-        ;
+        task_options[:project_id] = Project.new.id
       end
 
       def task_options


### PR DESCRIPTION
Assign a default project id (`Project.new`) to the `task_options` in CE. In Pro, this does nothing as the method is overridden.