### PR TITLE
Add project id when creating nodes

### DIFF
--- a/lib/dradis/plugins/content_service/issues.rb
+++ b/lib/dradis/plugins/content_service/issues.rb
@@ -64,7 +64,7 @@ module Dradis::Plugins::ContentService
     # the issue library cache has been initialized.
     def issue_cache
       @issue_cache ||= begin
-        issues_map = Issue.where(category_id: default_issue_category.id).map do |issue|
+        issues_map = all_issues.map do |issue|
           cache_key = [
             issue.fields['plugin'],
             issue.fields['plugin_id']

--- a/lib/dradis/plugins/content_service/nodes.rb
+++ b/lib/dradis/plugins/content_service/nodes.rb
@@ -34,7 +34,11 @@ module Dradis::Plugins::ContentService
         end
       end
 
-      parent.children.find_or_create_by(label: label, type_id: type_id)
+      parent.children.find_or_create_by(
+        label: label,
+        type_id: type_id,
+        project_id: parent.project_id
+      )
     end
 
     private


### PR DESCRIPTION
Currently, the content service is creating nodes without a `project` which makes them invalid. This change makes the node inherit the project id from its parent to make it valid.