### PR TITLE
all_content_blocks should return a relation so it can be chained with…

### DIFF
--- a/lib/dradis/plugins/content_service/content_blocks.rb
+++ b/lib/dradis/plugins/content_service/content_blocks.rb
@@ -3,7 +3,10 @@ module Dradis::Plugins::ContentService
     extend ActiveSupport::Concern
 
     def all_content_blocks
-      ContentBlock.where(project_id: project.id).order(:block_group)
+      ordered = ContentBlock.where(project_id: project.id).sort_by do |cb|
+        cb.title.downcase
+      end.map(&:id)
+      ContentBlock.where(id: ordered).order("field(id, #{ordered.join(',')})")
     end
 
     def create_content_block(args={})

--- a/lib/dradis/plugins/content_service/content_blocks.rb
+++ b/lib/dradis/plugins/content_service/content_blocks.rb
@@ -3,10 +3,7 @@ module Dradis::Plugins::ContentService
     extend ActiveSupport::Concern
 
     def all_content_blocks
-      ordered = ContentBlock.where(project_id: project.id).sort_by do |cb|
-        cb.title.downcase
-      end.map(&:id)
-      ContentBlock.where(id: ordered).order("field(id, #{ordered.join(',')})")
+      project.content_blocks
     end
 
     def create_content_block(args={})

--- a/lib/dradis/plugins/content_service/content_blocks.rb
+++ b/lib/dradis/plugins/content_service/content_blocks.rb
@@ -3,7 +3,7 @@ module Dradis::Plugins::ContentService
     extend ActiveSupport::Concern
 
     def all_content_blocks
-      ContentBlock.where(project_id: project.id).sort_by { |cb| cb.title.downcase }
+      ContentBlock.where(project_id: project.id).order(:block_group)
     end
 
     def create_content_block(args={})

--- a/spec/lib/dradis/plugins/content_service_spec.rb
+++ b/spec/lib/dradis/plugins/content_service_spec.rb
@@ -1,9 +1,21 @@
 require 'rails_helper'
 
 # These specs are coming from engines/dradispro-rules/spec/content_service_spec.rb
+# To run, execute from Dradis main app folder:
+#   bin/rspec [dradis-plugins path]/spec/lib/dradis/plugins/content_service_spec.rb
 
 describe Dradis::Plugins::ContentService::Base do
-  describe "Issues" do
+  let(:plugin)  { Dradis::Plugins::Nessus }
+  let(:project) { create(:project) }
+  let(:service) do
+    Dradis::Plugins::ContentService::Base.new(
+      plugin: plugin,
+      logger: Rails.logger,
+      project: project
+    )
+  end
+
+  describe 'Issues' do
     let(:create_issue) do
       service.create_issue_without_callback(id: plugin_id)
     end
@@ -14,7 +26,7 @@ describe Dradis::Plugins::ContentService::Base do
     # it's being stored within an instance of FindingCache, which
     # automatically wraps Issues in Findings.
 
-    describe "when the issue already exists in the cache" do
+    describe 'when the issue already exists in the cache' do
       let(:existing_issue) { create(:issue, text: cached_issue_text) }
       before { cache.store(existing_issue) }
 
@@ -22,7 +34,7 @@ describe Dradis::Plugins::ContentService::Base do
         expect{create_issue}.not_to change{Issue.count}
       end
 
-      it "returns the cached issue encapsulated in a finding" do
+      it 'returns the cached issue encapsulated in a finding' do
         finding = create_issue
         expect(finding).to be_a(Finding)
         expect(finding).to eq Finding.from_issue(existing_issue)
@@ -37,16 +49,36 @@ describe Dradis::Plugins::ContentService::Base do
         expect(new_issue.body).to match(/#\[plugin_id\]#\n*#{plugin_id}/)
       end
 
-      it "returns the new Issue encapsulated in a Finding" do
+      it 'returns the new Issue encapsulated in a Finding' do
         finding = create_issue
         expect(finding).to be_a(Finding)
         expect(finding).to eq Finding.from_issue(Issue.last)
       end
 
-      it "adds the new Finding to the cache" do
+      it 'adds the new Finding to the cache' do
         finding = create_issue
         expect(cache[cache_key]).to eq finding
       end
+    end
+  end
+
+  describe 'ContentBlocks' do
+    it 'returns content blocks ordered by title' do
+      cb1 = create(
+        :content_block,
+        content: "#[Title]#\r\nB\r\n#[Description]#\r\nContent Block B",
+        project: project
+      )
+      cb2 = create(
+        :content_block,
+        content: "#[Title]#\r\nA\r\n#[Description]#\r\nContent Block A",
+        project: project
+      )
+
+      expect(cb1.id).to be < cb2.id
+      content_blocks = service.all_content_blocks
+      expect(content_blocks.class).not_to be_an(Array)
+      expect(content_blocks.first.id).to eq cb2.id
     end
   end
 end

--- a/spec/lib/dradis/plugins/content_service_spec.rb
+++ b/spec/lib/dradis/plugins/content_service_spec.rb
@@ -61,24 +61,4 @@ describe Dradis::Plugins::ContentService::Base do
       end
     end
   end
-
-  describe 'ContentBlocks' do
-    it 'returns content blocks ordered by title' do
-      cb1 = create(
-        :content_block,
-        content: "#[Title]#\r\nB\r\n#[Description]#\r\nContent Block B",
-        project: project
-      )
-      cb2 = create(
-        :content_block,
-        content: "#[Title]#\r\nA\r\n#[Description]#\r\nContent Block A",
-        project: project
-      )
-
-      expect(cb1.id).to be < cb2.id
-      content_blocks = service.all_content_blocks
-      expect(content_blocks.class).not_to be_an(Array)
-      expect(content_blocks.first.id).to eq cb2.id
-    end
-  end
 end


### PR DESCRIPTION
… other '.where' calls.