### PR TITLE
`Node#project_id` does not always exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Dradis Framework 3.10.1 (November, 2018) ##
 
-*  Do not use `node.project_id` if the column does not exist
+*  Do not use `Node#project_id`
 
 ## Dradis Framework 3.10 (August, 2018) ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.10.1 (November, 2018) ##
+
+*  Do not use `node.project_id` if the column does not exist
+
 ## Dradis Framework 3.10 (August, 2018) ##
 
 *  Add default project to task options

--- a/lib/dradis/plugins/content_service/nodes.rb
+++ b/lib/dradis/plugins/content_service/nodes.rb
@@ -34,11 +34,14 @@ module Dradis::Plugins::ContentService
         end
       end
 
-      parent.children.find_or_create_by(
+      node_params = {
         label: label,
-        type_id: type_id,
-        project_id: parent.project_id
-      )
+        type_id: type_id
+      }
+
+      node_params[:project_id] = parent.project.id if parent.respond_to?(:project_id)
+
+      parent.children.find_or_create_by(node_params)
     end
 
     private

--- a/lib/dradis/plugins/content_service/nodes.rb
+++ b/lib/dradis/plugins/content_service/nodes.rb
@@ -34,14 +34,13 @@ module Dradis::Plugins::ContentService
         end
       end
 
-      node_params = {
+      new_node = parent.children.find_or_initialize_by(
         label: label,
         type_id: type_id
-      }
-
-      node_params[:project_id] = parent.project.id if parent.respond_to?(:project_id)
-
-      parent.children.find_or_create_by(node_params)
+      )
+      new_node.project = parent.project
+      new_node.save
+      new_node
     end
 
     private

--- a/lib/dradis/plugins/gem_version.rb
+++ b/lib/dradis/plugins/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
     module VERSION
       MAJOR = 3
       MINOR = 10
-      TINY  = 0
+      TINY  = 1
       PRE   = nil
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')


### PR DESCRIPTION
In some cases (CE) `node.project_id` does not exist.

We could just add to the model:

```
def project_id
  project.id
end
```

But then some magic methods may fail: `parent_node.find_or_create_by(project_id: ...)` because they try to use the database `node.project_id` column, that still does not exist.

So in this solution we check if the node has `project_id` available in the dradis-plugins content-service.