### PR TITLE
Update Module#parent usage for deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Dradis Framework 3.20 (December, 2020) ##
+## Dradis Framework 3.21 (February, 2021) ##
+
+*  Rename `parent` methods to `module_parent` as `Module#parent` is deprecated.
+
+## Dradis Framework 3.20 (January, 2021) ##
 
 *  No changes.
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,6 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
 
-#gem 'dradis_core', path: '/Users/etd/dradis/git/dradis/core'
-#gem 'dradis', :github => 'dradis/dradisframework' # temporarily here until 3.0.0.beta is released
-# git "https://github.com/dradis/dradisframework.git", :branch => 'dradis3.x' do
-#   gem 'dradis_core'
-# end
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in dradis-html_export.gemspec
 gemspec

--- a/lib/dradis/plugins/upload/base.rb
+++ b/lib/dradis/plugins/upload/base.rb
@@ -22,7 +22,7 @@ module Dradis::Plugins::Upload::Base
   extend ActiveSupport::Concern
 
   included do
-    parent.extend NamespaceClassMethods
+    module_parent.extend NamespaceClassMethods
   end
 
   module ClassMethods
@@ -41,7 +41,7 @@ module Dradis::Plugins::Upload::Base
     #     ]
     #   end
     def uploaders()
-      [parent]
+      [module_parent]
     end
   end
 


### PR DESCRIPTION
This branch is needed for the Rails/Ruby upgrade ongoing. [Module#parent has been deprecated](https://github.com/rails/rails/pull/34051) and our use of the old method makes pretty much _every_ plugin initialization raise warnings.