### PR TITLE
ContentService#create_evidence - Avoid dup Evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.22 (###, 2021) ##
+
+* ContentService#create_evidence: deduplicate Evidence from integrations.
+
 ## Dradis Framework 3.21 (February, 2021) ##
 
 *  Rename `parent` methods to `module_parent` as `Module#parent` is deprecated.

--- a/lib/dradis/plugins/content_service/evidence.rb
+++ b/lib/dradis/plugins/content_service/evidence.rb
@@ -7,10 +7,11 @@ module Dradis::Plugins::ContentService
       node    = args.fetch(:node, default_node_parent)
       issue   = args[:issue] || default_evidence_issue
 
-      evidence = node.evidence.new(issue_id: issue.id, content: content)
+      # Using node.evidence.new would result in some evidence being saved later on.
+      evidence = ::Evidence.new(issue_id: issue.id, content: content, node_id: node.id)
 
       if evidence.valid?
-        evidence.save
+        evidence = ::Evidence.find_or_create_by(issue_id: issue.id, node_id: node.id, content: content)
       else
         try_rescue_from_length_validation(
           model: evidence,


### PR DESCRIPTION
Before this change uploading the same file twice would result in a single set of Issues, but duplicate Evidence all over.

With this PR we're checking each Evidence, if an exact match is already found (same Issue, Content, and Node), then we don't insert it again.