### PR TITLE
Plugin template names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+[v#.#.#] ([month] [YYYY])
+  - Provide default plugin template mappings
+
 v4.3.0 (February 2022)
   - No changes
 

--- a/lib/dradis/plugins/upload/base.rb
+++ b/lib/dradis/plugins/upload/base.rb
@@ -51,8 +51,8 @@ module Dradis::Plugins::Upload::Base
     #   end
     #
     # The default implementation returns nothing at all.
-    def template_names
-      { module_parent => [] }
+    def templates
+      uploaders.each_with_object({}) { |uploader, acc| acc[uploader] = uploader::Importer.templates }
     end
   end
 

--- a/lib/dradis/plugins/upload/base.rb
+++ b/lib/dradis/plugins/upload/base.rb
@@ -43,6 +43,17 @@ module Dradis::Plugins::Upload::Base
     def uploaders()
       [module_parent]
     end
+
+    # Return the list of templates that the module provides
+    #   def self.template_names
+    #     { Dradis::Plugins::Burp::Html => { evidence: 'html_evidence', issue: 'issue' } },
+    #     { Dradis::Plugins::Burp::Xml => { evidence: 'evidence', issue: 'issue' } }
+    #   end
+    #
+    # The default implementation returns nothing at all.
+    def template_names
+      { module_parent => [] }
+    end
   end
 
   module NamespaceClassMethods

--- a/lib/dradis/plugins/upload/base.rb
+++ b/lib/dradis/plugins/upload/base.rb
@@ -40,7 +40,7 @@ module Dradis::Plugins::Upload::Base
     #       Dradis::Plugins::Projects::Template
     #     ]
     #   end
-    def uploaders()
+    def uploaders
       [module_parent]
     end
 

--- a/lib/dradis/plugins/upload/importer.rb
+++ b/lib/dradis/plugins/upload/importer.rb
@@ -15,6 +15,10 @@ module Dradis
           :template_service
         )
 
+        def self.templates
+          { evidence: 'evidence', issue: 'issue' }
+        end
+
         def initialize(args={})
           @options = args
 


### PR DESCRIPTION
### Summary

Add a base method for all upload plugins to offer a template_names mapping.

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.