### PR TITLE
Bump version to 4.6.1

### DIFF
--- a/lib/dradis/plugins/gem_version.rb
+++ b/lib/dradis/plugins/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
     module VERSION
       MAJOR = 4
       MINOR = 6
-      TINY  = 0
+      TINY  = 1
       PRE   = nil
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')


### PR DESCRIPTION
Need to bump version to 4.6.1 so that it can be published to RubyGems, as 4.6.0 needed to be taken down for merge fix