### PR TITLE
Add state for content blocks

### DIFF
--- a/lib/dradis/plugins/content_service/content_blocks.rb
+++ b/lib/dradis/plugins/content_service/content_blocks.rb
@@ -9,7 +9,7 @@ module Dradis::Plugins::ContentService
     def create_content_block(args={})
       block_group    = args.fetch(:block_group, default_content_block_group)
       content        = args.fetch(:content, default_content_block_content)
-      state          = args.fetch(:state)
+      state          = args.fetch(:state, :published)
       user_id        = args.fetch(:user_id)
 
       content_block = ContentBlock.new(

--- a/lib/dradis/plugins/content_service/content_blocks.rb
+++ b/lib/dradis/plugins/content_service/content_blocks.rb
@@ -9,12 +9,14 @@ module Dradis::Plugins::ContentService
     def create_content_block(args={})
       block_group    = args.fetch(:block_group, default_content_block_group)
       content        = args.fetch(:content, default_content_block_content)
+      state          = args.fetch(:state)
       user_id        = args.fetch(:user_id)
 
       content_block = ContentBlock.new(
         content: content,
         block_group: block_group,
         project_id: project.id,
+        state: state,
         user_id: user_id
       )
 


### PR DESCRIPTION
### Spec
With the introduction of the state column for issues/content blocks, we want to make sure that the state can be exported and imported along with the project.

**Proposed solution**
Implement an import/export V4 that adds the state attribute.