### PR TITLE
QA export

### DIFF
--- a/lib/dradis/plugins/content_service/content_blocks.rb
+++ b/lib/dradis/plugins/content_service/content_blocks.rb
@@ -3,7 +3,7 @@ module Dradis::Plugins::ContentService
     extend ActiveSupport::Concern
 
     def all_content_blocks
-      project.content_blocks
+      project.content_blocks.published
     end
 
     def create_content_block(args={})
@@ -22,6 +22,8 @@ module Dradis::Plugins::ContentService
 
       if content_block.valid?
         content_block.save
+
+        return content_block
       else
         try_rescue_from_length_validation(
           model: content_block,

--- a/lib/dradis/plugins/content_service/issues.rb
+++ b/lib/dradis/plugins/content_service/issues.rb
@@ -3,7 +3,7 @@ module Dradis::Plugins::ContentService
     extend ActiveSupport::Concern
 
     def all_issues
-      project.issues.where(category_id: default_issue_category.id)
+      project.issues.published.where(category_id: default_issue_category.id)
     end
 
     def create_issue(args={})

--- a/spec/lib/dradis/plugins/content_service/content_blocks_spec.rb
+++ b/spec/lib/dradis/plugins/content_service/content_blocks_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+# To run, execute from Dradis Pro main app folder:
+#   bin/rspec [dradis-plugins path]/spec/lib/dradis/plugins/content_service/content_blocks_spec.rb
+
+describe 'Content Block content service' do
+  let(:plugin) { Dradis::Plugins::Nessus }
+  let(:plugin_id) { '111' }
+  let(:project) { create(:project) }
+  let(:service) do
+    Dradis::Plugins::ContentService::Base.new(
+      plugin: plugin,
+      logger: Rails.logger,
+      project: project
+    )
+  end
+
+  describe '#all_content_blocks' do
+    before do
+      @draft_content = create_list(:content_block, 10, project: project, state: :draft)
+      @review_content = create_list(:content_block, 10, project: project, state: :ready_for_review)
+      @published_content = create_list(:content_block, 10, project: project, state: :published)
+    end
+
+    it 'returns only the published content blocks' do
+      expect(service.all_content_blocks.to_a).to match_array(@published_content)
+    end
+  end
+end

--- a/spec/lib/dradis/plugins/content_service/issues_spec.rb
+++ b/spec/lib/dradis/plugins/content_service/issues_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-# These specs are coming from engines/dradispro-rules/spec/content_service_spec.rb
 # To run, execute from Dradis main app folder:
 #   bin/rspec [dradis-plugins path]/spec/lib/dradis/plugins/content_service/issues_spec.rb
 
-describe Dradis::Plugins::ContentService::Base do
-  let(:plugin)  { Dradis::Plugins::Nessus }
+describe 'Issues content service' do
+  let(:plugin) { Dradis::Plugins::Nessus }
+  let(:plugin_id) { '111' }
   let(:project) { create(:project) }
   let(:service) do
     Dradis::Plugins::ContentService::Base.new(
@@ -17,47 +17,39 @@ describe Dradis::Plugins::ContentService::Base do
 
   describe 'Issues' do
     let(:create_issue) do
-      service.create_issue_without_callback(id: plugin_id)
+      service.create_issue(text: "#[Title]#\nTest Issue\n", id: plugin_id, state: :ready_for_review)
     end
 
-    # Remember: even though we're calling create_issue_without_callback,
-    # that method will still call issue_cache_with_callback internally.
-    # So when we store an issue in the issue_cache/finding_cache below,
-    # it's being stored within an instance of FindingCache, which
-    # automatically wraps Issues in Findings.
-
     describe 'when the issue already exists in the cache' do
-      let(:existing_issue) { create(:issue, text: cached_issue_text) }
-      before { cache.store(existing_issue) }
-
-      it "doesn't create a new issue" do
-        expect{create_issue}.not_to change{Issue.count}
+      before do
+        issue = create(:issue, text: "#[Title]#\nTest Issue\n", id: plugin_id)
+        service.issue_cache.store("nessus-#{plugin_id}", issue)
       end
 
-      it 'returns the cached issue encapsulated in a finding' do
-        finding = create_issue
-        expect(finding).to be_a(Finding)
-        expect(finding).to eq Finding.from_issue(existing_issue)
+      it 'does not create a new issue' do
+        expect { create_issue }.not_to change { Issue.count }
       end
     end
 
     describe "when the issue doesn't already exist in the cache" do
       it "creates a new Issue containing 'plugin' and 'plugin_id'" do
         new_issue = nil
-        expect{new_issue = create_issue}.to change{Issue.count}.by(1)
-        expect(new_issue.body).to match(/#\[plugin\]#\n*#{plugin_name}/)
-        expect(new_issue.body).to match(/#\[plugin_id\]#\n*#{plugin_id}/)
+        plugin_name = "#{plugin}::Engine".constantize.plugin_name
+        expect { new_issue = create_issue }.to change { Issue.count }.by(1)
+        expect(new_issue.text).to match(/#\[plugin\]#\n*#{plugin_name}/)
+        expect(new_issue.text).to match(/#\[plugin_id\]#\n*#{plugin_id}/)
+      end
+    end
+
+    describe '#all_issues' do
+      before do
+        @draft_issues = create_list(:issue, 10, project: project, state: :draft)
+        @review_issues = create_list(:issue, 10, project: project, state: :ready_for_review)
+        @published_issues = create_list(:issue, 10, project: project, state: :published)
       end
 
-      it 'returns the new Issue encapsulated in a Finding' do
-        finding = create_issue
-        expect(finding).to be_a(Finding)
-        expect(finding).to eq Finding.from_issue(Issue.last)
-      end
-
-      it 'adds the new Finding to the cache' do
-        finding = create_issue
-        expect(cache[cache_key]).to eq finding
+      it 'returns only the published issues' do
+        expect(service.all_issues.to_a).to match_array(@published_issues)
       end
     end
   end


### PR DESCRIPTION
### Spec
To make sure that only Quality Assured issues/content blocks make it out in a report , we need to limit the exported issues/content blocks to only the "Published" state.

**Proposed solution**
Update the dradis-plugins content service to return only the published records.