### PR TITLE
Fix deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.9.0 (XXX 2023)
+  - Fix deduplication of findings
+
 v4.8.0 (April 2023)
   - Add support for issue and content block states
 

--- a/lib/dradis/plugins/content_service/issues.rb
+++ b/lib/dradis/plugins/content_service/issues.rb
@@ -76,7 +76,7 @@ module Dradis::Plugins::ContentService
     # the issue library cache has been initialized.
     def issue_cache
       @issue_cache ||= begin
-        issues_map = all_issues.map do |issue|
+        issues_map = project.issues.map do |issue|
           cache_key = [
             issue.fields['plugin'],
             issue.fields['plugin_id']

--- a/lib/dradis/plugins/gem_version.rb
+++ b/lib/dradis/plugins/gem_version.rb
@@ -7,7 +7,7 @@ module Dradis
 
     module VERSION
       MAJOR = 4
-      MINOR = 8
+      MINOR = 9
       TINY  = 0
       PRE   = nil
 


### PR DESCRIPTION
### Spec
Uploading a tool output can sometimes not deduplicate a finding causing the same finding to appear in the project.

This happens because the issue_cache in the dradis-plugins only pulls the published issues.

**Proposed solution**
Pull all the issues in a project for the issue_cache.