### PR TITLE
Encrypted Settings: Initial steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+vX.X.X (Mmmm 2023)
+  - Engine settings: can now be stored encrypted
+
 v4.8.0 (April 2023)
   - Add support for issue and content block states
 

--- a/dradis-plugins.gemspec
+++ b/dradis-plugins.gemspec
@@ -20,12 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
 
-  spec.add_development_dependency 'bundler', '>= 2.2.33'
-  spec.add_development_dependency 'rake', '>= 12.3.3'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec-rails'
-
-  # By not including Rails as a dependency, we can use the gem with different
-  # versions of Rails (a sure recipe for disaster, I'm sure), which is needed
-  # until we bump Dradis Pro to 4.1.
-  # s.add_dependency 'rails', '~> 4.1.1'
 end

--- a/lib/dradis/plugins.rb
+++ b/lib/dradis/plugins.rb
@@ -84,6 +84,8 @@ require 'dradis/plugins/upload'
 # Common functionality
 require 'dradis/plugins/configurable'
 require 'dradis/plugins/settings'
+require 'dradis/plugins/settings/adapters/db'
+require 'dradis/plugins/settings/adapters/encrypted_configuration'
 require 'dradis/plugins/templates'
 require 'dradis/plugins/thor'
 require 'dradis/plugins/thor_helper'

--- a/lib/dradis/plugins/configurable.rb
+++ b/lib/dradis/plugins/configurable.rb
@@ -9,6 +9,11 @@ module Dradis::Plugins
         @settings_namespace || plugin_name
       end
 
+      def addon_encrypted_settings(namespace = nil, &block)
+        @settings_namespace = namespace if namespace
+        yield self if block_given?
+      end
+
       def addon_settings(namespace = nil, &block)
         @settings_namespace = namespace if namespace
         yield self if block_given?
@@ -19,8 +24,12 @@ module Dradis::Plugins
       end
     end
 
+    def encrypted_settings
+      @encrypted_settings ||= Dradis::Plugins::Settings.new(self.class.settings_namespace, adapter: :encrypted_configuration)
+      end
+
     def settings
-      @settings ||= Dradis::Plugins::Settings.new(self.class.settings_namespace)
+      @settings ||= Dradis::Plugins::Settings.new(self.class.settings_namespace, adapter: :db)
     end
   end
 end

--- a/lib/dradis/plugins/configurable.rb
+++ b/lib/dradis/plugins/configurable.rb
@@ -6,16 +6,16 @@ module Dradis::Plugins
       delegate :encrypted_settings, :settings, to: :instance
 
       def settings_namespace
-        @settings_namespace || plugin_name
+        @settings_namespace ||= plugin_name
       end
 
       def addon_encrypted_settings(namespace = nil, &block)
-        @settings_namespace = namespace if namespace
+        @settings_namespace = namespace
         yield self if block_given?
       end
 
       def addon_settings(namespace = nil, &block)
-        @settings_namespace = namespace if namespace
+        @settings_namespace = namespace
         yield self if block_given?
       end
 

--- a/lib/dradis/plugins/configurable.rb
+++ b/lib/dradis/plugins/configurable.rb
@@ -3,7 +3,7 @@ module Dradis::Plugins
     extend ActiveSupport::Concern
 
     module ClassMethods
-      delegate :settings, to: :instance
+      delegate :encrypted_settings, :settings, to: :instance
 
       def settings_namespace
         @settings_namespace || plugin_name
@@ -26,7 +26,7 @@ module Dradis::Plugins
 
     def encrypted_settings
       @encrypted_settings ||= Dradis::Plugins::Settings.new(self.class.settings_namespace, adapter: :encrypted_configuration)
-      end
+    end
 
     def settings
       @settings ||= Dradis::Plugins::Settings.new(self.class.settings_namespace, adapter: :db)

--- a/lib/dradis/plugins/settings.rb
+++ b/lib/dradis/plugins/settings.rb
@@ -2,10 +2,11 @@ module Dradis::Plugins
   class Settings
     attr_reader :namespace
 
-    def initialize(namespace)
+    def initialize(namespace, adapter: :db)
       @namespace = namespace
       @dirty_options ||= {}
       @default_options ||= { enabled: true }.with_indifferent_access
+      assign_adapter(adapter)
     end
 
     def respond_to?(name)
@@ -16,14 +17,18 @@ module Dradis::Plugins
       @default_options.except(:enabled).map do |key, value|
         {
           name: key.to_sym,
-          value: value = dirty_or_db_setting_or_default(key.to_sym),
+          value: value = dirty_or_stored_or_default(key.to_sym),
           default: is_default?(key, value)
         }
       end.sort_by{ |o| o[:name] }
     end
 
     def save
-      @dirty_options.reject{ |k, v| v.present? && v == db_setting(k) }.each{ |k, v| write_to_db(k, v) }
+      @dirty_options.reject do |k, v|
+        v.present? && v == read(namespaced_key(k))
+      end.each do |k, v|
+        write(namespaced_key(k), v)
+      end
     end
 
     def update_settings(opts = {})
@@ -36,7 +41,7 @@ module Dradis::Plugins
     def reset_defaults!
       @dirty_options = {}
       @default_options.each do |key, value|
-        Configuration.where(name: namespaced_key(key)).each(&:destroy)
+        delete(namespaced_key(key)) if exists?(namespaced_key(key))
       end
     end
 
@@ -45,6 +50,8 @@ module Dradis::Plugins
     end
 
     private
+    attr_reader :adapter
+    delegate :delete, :exists?, :read, :write, to: :adapter
 
     # ---------------------------------------------------- Method missing magic
     def method_missing(name, *args, &blk)
@@ -53,31 +60,30 @@ module Dradis::Plugins
       elsif name.to_s =~ /=$/
         @dirty_options[$`.to_sym] = args.first
       elsif @default_options.key?(name)
-        dirty_or_db_setting_or_default(name)
+        dirty_or_stored_or_default(name)
       else
         super
       end
     end
     # --------------------------------------------------- /Method missing magic
 
-    def write_to_db(key, value)
-      db_setting = Configuration.find_or_create_by(name: namespaced_key(key))
-      db_setting.update_attribute(:value, value)
-    end
-
-
-    def db_setting(key)
-      Configuration.where(name: namespaced_key(key)).first.value rescue nil
+    def assign_adapter(name)
+      adapters = { db: Adapters::Db, encrypted_configuration: Adapters::EncryptedConfiguration }
+      if adapters.key?(name)
+        @adapter = adapters[name].new
+      else
+        raise ArgumentError
+      end
     end
 
     # This method looks up in the configuration repository DB to see if the
     # user has provided a value for the given setting. If not, the default
     # value is returned.
-    def dirty_or_db_setting_or_default(key)
+    def dirty_or_stored_or_default(key)
       if @dirty_options.key?(key)
         @dirty_options[key]
-      elsif Configuration.exists?(name: namespaced_key(key))
-        db_setting(key)
+      elsif exists?(namespaced_key(key))
+        read(namespaced_key(key))
       else
         @default_options[key]
       end

--- a/lib/dradis/plugins/settings.rb
+++ b/lib/dradis/plugins/settings.rb
@@ -25,9 +25,9 @@ module Dradis::Plugins
 
     def save
       @dirty_options.reject do |k, v|
-        v.present? && v == read(namespaced_key(k))
+        v.present? && v == read(k)
       end.each do |k, v|
-        write(namespaced_key(k), v)
+        write(k, v)
       end
     end
 
@@ -41,7 +41,7 @@ module Dradis::Plugins
     def reset_defaults!
       @dirty_options = {}
       @default_options.each do |key, value|
-        delete(namespaced_key(key)) if exists?(namespaced_key(key))
+        delete(key) if exists?(key)
       end
     end
 
@@ -70,7 +70,7 @@ module Dradis::Plugins
     def assign_adapter(name)
       adapters = { db: Adapters::Db, encrypted_configuration: Adapters::EncryptedConfiguration }
       if adapters.key?(name)
-        @adapter = adapters[name].new
+        @adapter = adapters[name].new(namespace)
       else
         raise ArgumentError
       end
@@ -82,16 +82,11 @@ module Dradis::Plugins
     def dirty_or_stored_or_default(key)
       if @dirty_options.key?(key)
         @dirty_options[key]
-      elsif exists?(namespaced_key(key))
-        read(namespaced_key(key))
+      elsif exists?(key)
+        read(key)
       else
         @default_options[key]
       end
-    end
-
-    # Builds namespaced key
-    def namespaced_key(key)
-      [self.namespace.to_s, key.to_s.underscore].join(":")
     end
   end
 end

--- a/lib/dradis/plugins/settings/adapters/db.rb
+++ b/lib/dradis/plugins/settings/adapters/db.rb
@@ -13,7 +13,7 @@ module Dradis::Plugins::Settings::Adapters
     end
 
     def read(key)
-      Configuration.find_by(name: namespaced_key(key)).value rescue nil
+      Configuration.find_by(name: namespaced_key(key))&.value
     end
 
     def write(key, value)

--- a/lib/dradis/plugins/settings/adapters/db.rb
+++ b/lib/dradis/plugins/settings/adapters/db.rb
@@ -1,20 +1,30 @@
 module Dradis::Plugins::Settings::Adapters
   class Db
+    def initialize(namespace)
+      @namespace = namespace.to_s
+    end
+
     def delete(key)
-      Configuration.find_by(name: key).destroy
+      Configuration.find_by(name: namespaced_key(key)).destroy
     end
 
     def exists?(key)
-      Configuration.exists?(name: key)
+      Configuration.exists?(name: namespaced_key(key))
     end
 
     def read(key)
-      Configuration.find_by(name: key).value rescue nil
+      Configuration.find_by(name: namespaced_key(key)).value rescue nil
     end
 
     def write(key, value)
-      db_setting = Configuration.find_or_create_by(name: key)
+      db_setting = Configuration.find_or_create_by(name: namespaced_key(key))
       db_setting.update_attribute(:value, value)
+    end
+
+    private
+
+    def namespaced_key(key)
+      [@namespace, key.to_s.underscore].join(':')
     end
   end
 end

--- a/lib/dradis/plugins/settings/adapters/db.rb
+++ b/lib/dradis/plugins/settings/adapters/db.rb
@@ -1,0 +1,20 @@
+module Dradis::Plugins::Settings::Adapters
+  class Db
+    def delete(key)
+      Configuration.find_by(name: key).destroy
+    end
+
+    def exists?(key)
+      Configuration.exists?(name: key)
+    end
+
+    def read(key)
+      Configuration.find_by(name: key).value rescue nil
+    end
+
+    def write(key, value)
+      db_setting = Configuration.find_or_create_by(name: key)
+      db_setting.update_attribute(:value, value)
+    end
+  end
+end

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -14,11 +14,11 @@ module Dradis::Plugins::Settings::Adapters
     end
 
     def exists?(key)
-      configuration.config[@namespace].key?(key) rescue false
+      !!configuration.config[@namespace]&.key?(key)
     end
 
     def read(key)
-      configuration.config[@namespace][key] rescue nil
+      configuration.config[@namespace].fetch(key, nil)
     end
 
     def write(key, value)

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -1,12 +1,9 @@
 module Dradis::Plugins::Settings::Adapters
   class EncryptedConfiguration
-    attr_accessor :config_path
-    attr_reader :key_path
+    attr_writer :config_path
 
     def initialize(namespace)
       @namespace = namespace
-      @config_path = Rails.root.join('config', 'shared', 'dradis-plugins.yml.enc')
-      @key_path = Rails.root.join('config', 'shared', 'dradis-plugins.key')
     end
 
     def delete(key)
@@ -35,6 +32,10 @@ module Dradis::Plugins::Settings::Adapters
     end
 
     private
+    def config_path
+      @config_path ||= Rails.root.join('config', 'shared', 'dradis-plugins.yml.enc')
+    end
+
     def configuration
       @configuration ||= begin
           create_key unless key_path.exist?
@@ -48,6 +49,10 @@ module Dradis::Plugins::Settings::Adapters
 
     def create_key
       File.write(key_path, ActiveSupport::EncryptedConfiguration.generate_key)
+    end
+
+    def key_path
+      @key_path ||= Rails.root.join('config', 'shared', 'dradis-plugins.key')
     end
   end
 end

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -17,14 +17,15 @@ module Dradis::Plugins::Settings::Adapters
     end
 
     def exists?(key)
-      configuration.config[@namespace].key?(key)
+      configuration.config[@namespace].key?(key) rescue false
     end
 
     def read(key)
-      configuration.config[@namespace][key]
+      configuration.config[@namespace][key] rescue nil
     end
 
     def write(key, value)
+      configuration.config[@namespace] ||= {}
       configuration.config[@namespace][key] = value
       configuration.write(configuration.config.to_yaml)
     end

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -1,0 +1,19 @@
+module Dradis::Plugins::Settings::Adapters
+  class EncryptedConfiguration
+    def delete(key)
+      raise NotImplementedError
+    end
+
+    def exists?(key)
+      raise NotImplementedError
+    end
+
+    def read(key)
+      raise NotImplementedError
+    end
+
+    def write(key, value)
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -1,19 +1,52 @@
 module Dradis::Plugins::Settings::Adapters
   class EncryptedConfiguration
+    attr_accessor :config_path
+    attr_reader :key_path
+
+    def initialize(namespace)
+      @namespace = namespace
+      @config_path = Rails.root.join('config', 'shared', 'dradis-plugins.yml.enc')
+      @key_path = Rails.root.join('config', 'shared', 'dradis-plugins.key')
+    end
+
     def delete(key)
-      raise NotImplementedError
+      if exists?(key)
+        configuration.config[@namespace].delete(key)
+        configuration.write(configuration.config.to_yaml)
+      end
     end
 
     def exists?(key)
-      raise NotImplementedError
+      configuration.config[@namespace].key?(key)
     end
 
     def read(key)
-      raise NotImplementedError
+      configuration.config[@namespace][key]
     end
 
     def write(key, value)
-      raise NotImplementedError
+      configuration.config[@namespace][key] = value
+      configuration.write(configuration.config.to_yaml)
+    end
+
+    def key_path=(string_or_pathname)
+      @key_path = Pathname.new(string_or_pathname)
+    end
+
+    private
+    def configuration
+      @configuration ||= begin
+          create_key unless key_path.exist?
+
+          ActiveSupport::EncryptedConfiguration.new(
+            config_path: config_path, key_path: key_path,
+            env_key: 'RAILS_MASTER_KEY', raise_if_missing_key: true
+          )
+        end
+    end
+
+    def create_key
+      File.write(key_path, ActiveSupport::EncryptedConfiguration.generate_key)
     end
   end
 end

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -18,7 +18,7 @@ module Dradis::Plugins::Settings::Adapters
     end
 
     def read(key)
-      configuration.config[@namespace].fetch(key, nil)
+      configuration.config.fetch(@namespace, {}).fetch(key, nil)
     end
 
     def write(key, value)

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -13,11 +13,14 @@ describe Dradis::Plugins::Base do
 
   describe '#enabled?' do
     it 'returns default value' do
-      expect(TestEngine.enabled?).to eq(false)
+      expect(TestEngine.enabled?).to eq(true)
     end
   end
   describe '#enable!' do
     it 'sets enabled to true' do
+      TestEngine.settings.enabled = false
+      TestEngine.settings.save
+
       expect { TestEngine.enable! }.to change {
         TestEngine.enabled?
       }.from(false).to(true)
@@ -25,7 +28,9 @@ describe Dradis::Plugins::Base do
   end
   describe '#disable!' do
     it 'sets enabled to false' do
-      TestEngine.enable!
+      TestEngine.settings.enabled = true
+      TestEngine.settings.save
+
       expect { TestEngine.disable! }.to change {
         TestEngine.enabled?
       }.from(true).to(false)

--- a/spec/lib/dradis/plugins/content_service/boards_spec.rb
+++ b/spec/lib/dradis/plugins/content_service/boards_spec.rb
@@ -20,7 +20,7 @@ describe Dradis::Plugins::ContentService::Boards do
         node = create(:node, project: project)
         node_board = create(:board, node: node, project: project)
 
-        boards = service.all_boards
+        boards = service.project_boards
 
         expect(boards).to include(board)
         expect(boards).to_not include(node_board)

--- a/spec/lib/dradis/plugins/settings/adapters/encrypted_configuration_spec.rb
+++ b/spec/lib/dradis/plugins/settings/adapters/encrypted_configuration_spec.rb
@@ -15,59 +15,98 @@ describe Dradis::Plugins::Settings::Adapters::EncryptedConfiguration do
     ec
   end
 
-  DEFAULT_CONFIG = { rspec: { key: :lorem_ipsum, key2: :dolor_sit } }.to_yaml.freeze
+  context 'With an empty config file' do
+    before(:all) do
+      @tmpdir = Dir.mktmpdir('config-')
+      @credentials_config_path = File.join(@tmpdir, 'empty.yml.enc')
+      @credentials_key_path = File.join(@tmpdir, 'empty.key')
+    end
 
-  before(:all) do
-    @tmpdir = Dir.mktmpdir('config-')
-    @credentials_config_path = File.join(@tmpdir, 'credentials.yml.enc')
-    @credentials_key_path = File.join(@tmpdir, 'master.key')
+    describe '#delete' do
+      it 'becomes a no-op' do
+        expect { subject.delete(:key) }.to_not raise_error
+      end
+    end
 
-    File.write(@credentials_key_path, ActiveSupport::EncryptedConfiguration.generate_key)
+    describe '#exists' do
+      it 'is always false' do
+        expect(subject.exists?(:key)).to be(false)
+        expect(subject.exists?(:key2)).to be(false)
+      end
+    end
 
-    @credentials = ActiveSupport::EncryptedConfiguration.new(
-      config_path: @credentials_config_path, key_path: @credentials_key_path,
-      env_key: 'RAILS_MASTER_KEY', raise_if_missing_key: true
-    )
+    describe '#read' do
+      it 'always returns nil' do
+        expect(subject.read(:key)).to eq(nil)
+        expect(subject.read(:key2)).to eq(nil)
+      end
+    end
 
-    @credentials.write(DEFAULT_CONFIG)
+    describe '#write' do
+      it 'inits the namespace and stores the setting' do
+        expect { subject.write(:key, :value) }.to_not raise_error
+        expect(File.size(@credentials_config_path)).to_not be(0)
+
+        File.unlink @credentials_config_path
+      end
+    end
   end
 
-  after(:all) do
-    FileUtils.rm_rf @tmpdir
-  end
+  context 'With a working config file' do
+    DEFAULT_CONFIG = { rspec: { key: :lorem_ipsum, key2: :dolor_sit } }.to_yaml.freeze
 
-  describe '#delete' do
-    it 'removes a value from disk' do
-      subject.delete(:key2)
+    before(:all) do
+      @tmpdir = Dir.mktmpdir('config-')
+      @credentials_config_path = File.join(@tmpdir, 'credentials.yml.enc')
+      @credentials_key_path = File.join(@tmpdir, 'master.key')
 
-      @credentials.instance_variable_set('@config', nil)
-      expect(@credentials.config[:rspec].key?(:key)).to be(true)
-      expect(@credentials.config[:rspec].key?(:key2)).to be(false)
+      File.write(@credentials_key_path, ActiveSupport::EncryptedConfiguration.generate_key)
+
+      @credentials = ActiveSupport::EncryptedConfiguration.new(
+        config_path: @credentials_config_path, key_path: @credentials_key_path,
+        env_key: 'RAILS_MASTER_KEY', raise_if_missing_key: true
+      )
+
       @credentials.write(DEFAULT_CONFIG)
     end
-  end
 
-  describe '#exists' do
-    it 'finds an existing value' do
-      expect(subject.exists?(:key)).to be(true)
+    after(:all) do
+      FileUtils.rm_rf @tmpdir
     end
-    it 'detects an inexisting value' do
-      expect(subject.exists?(:key3)).to be(false)
-    end
-  end
 
-  describe '#read' do
-    it 'loads an already existing value' do
-      expect(subject.read(:key)).to eq(:lorem_ipsum)
-    end
-  end
+    describe '#delete' do
+      it 'removes a value from disk' do
+        subject.delete(:key2)
 
-  describe '#write' do
-    it 'stores a value on disk' do
-      subject.write(:new_key, :new_value)
-      @credentials.instance_variable_set('@config', nil)
-      expect(@credentials.config[:rspec][:new_key]).to eq(:new_value)
-      @credentials.write(DEFAULT_CONFIG)
+        @credentials.instance_variable_set('@config', nil)
+        expect(@credentials.config[:rspec].key?(:key)).to be(true)
+        expect(@credentials.config[:rspec].key?(:key2)).to be(false)
+        @credentials.write(DEFAULT_CONFIG)
+      end
+    end
+
+    describe '#exists' do
+      it 'finds an existing value' do
+        expect(subject.exists?(:key)).to be(true)
+      end
+      it 'detects an inexisting value' do
+        expect(subject.exists?(:key3)).to be(false)
+      end
+    end
+
+    describe '#read' do
+      it 'loads an already existing value' do
+        expect(subject.read(:key)).to eq(:lorem_ipsum)
+      end
+    end
+
+    describe '#write' do
+      it 'stores a value on disk' do
+        subject.write(:new_key, :new_value)
+        @credentials.instance_variable_set('@config', nil)
+        expect(@credentials.config[:rspec][:new_key]).to eq(:new_value)
+        @credentials.write(DEFAULT_CONFIG)
+      end
     end
   end
 end

--- a/spec/lib/dradis/plugins/settings/adapters/encrypted_configuration_spec.rb
+++ b/spec/lib/dradis/plugins/settings/adapters/encrypted_configuration_spec.rb
@@ -1,0 +1,73 @@
+#
+# This spec must be run from Dradis root dir.
+#
+# Configuration init from:
+#   https://github.com/rails/rails/blob/main/activesupport/test/encrypted_configuration_test.rb
+#
+require 'rails_helper'
+
+describe Dradis::Plugins::Settings::Adapters::EncryptedConfiguration do
+
+  subject do
+    ec = Dradis::Plugins::Settings::Adapters::EncryptedConfiguration.new(:rspec)
+    ec.config_path = @credentials_config_path
+    ec.key_path = @credentials_key_path
+    ec
+  end
+
+  DEFAULT_CONFIG = { rspec: { key: :lorem_ipsum, key2: :dolor_sit } }.to_yaml.freeze
+
+  before(:all) do
+    @tmpdir = Dir.mktmpdir('config-')
+    @credentials_config_path = File.join(@tmpdir, 'credentials.yml.enc')
+    @credentials_key_path = File.join(@tmpdir, 'master.key')
+
+    File.write(@credentials_key_path, ActiveSupport::EncryptedConfiguration.generate_key)
+
+    @credentials = ActiveSupport::EncryptedConfiguration.new(
+      config_path: @credentials_config_path, key_path: @credentials_key_path,
+      env_key: 'RAILS_MASTER_KEY', raise_if_missing_key: true
+    )
+
+    @credentials.write(DEFAULT_CONFIG)
+  end
+
+  after(:all) do
+    FileUtils.rm_rf @tmpdir
+  end
+
+  describe '#delete' do
+    it 'removes a value from disk' do
+      subject.delete(:key2)
+
+      @credentials.instance_variable_set('@config', nil)
+      expect(@credentials.config[:rspec].key?(:key)).to be(true)
+      expect(@credentials.config[:rspec].key?(:key2)).to be(false)
+      @credentials.write(DEFAULT_CONFIG)
+    end
+  end
+
+  describe '#exists' do
+    it 'finds an existing value' do
+      expect(subject.exists?(:key)).to be(true)
+    end
+    it 'detects an inexisting value' do
+      expect(subject.exists?(:key3)).to be(false)
+    end
+  end
+
+  describe '#read' do
+    it 'loads an already existing value' do
+      expect(subject.read(:key)).to eq(:lorem_ipsum)
+    end
+  end
+
+  describe '#write' do
+    it 'stores a value on disk' do
+      subject.write(:new_key, :new_value)
+      @credentials.instance_variable_set('@config', nil)
+      expect(@credentials.config[:rspec][:new_key]).to eq(:new_value)
+      @credentials.write(DEFAULT_CONFIG)
+    end
+  end
+end

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -19,7 +19,6 @@ describe Dradis::Plugins::Settings do
   end
 
   it "sets and return default values" do
-    expect(TestEngine::settings.enabled).to eq(false)
     expect(TestEngine::settings.host).to eq('localhost')
     expect(TestEngine::settings.port).to eq(80)
   end


### PR DESCRIPTION
Decouple settings from the bakcend used to store them. Extract the default storage to a DB adapter. Include a yet-to-be implemented EncryptedConfiguration adapter.