### PR TITLE
Fix template service regex

### DIFF
--- a/lib/dradis/plugins/template_service.rb
+++ b/lib/dradis/plugins/template_service.rb
@@ -3,21 +3,20 @@ module Dradis
     class TemplateService
       attr_accessor :logger, :template, :templates_dir
 
-      def initialize(args={})
+      def initialize(args = {})
         @plugin        = args.fetch(:plugin)
         @templates_dir = args[:templates_dir] || default_templates_dir
       end
 
-
       # For a given entry, return a text blob resulting from applying the
       # chosen template to the supplied entry.
-      def process_template(args={})
+      def process_template(args = {})
         self.template = args[:template]
         data          = args[:data]
 
         processor = @plugin::FieldProcessor.new(data: data)
 
-        template_source.gsub( /%(.*?)%/ ) do |field|
+        template_source.gsub(/%(\S*?)%/) do |field|
           name = field[1..-2]
           if fields.include?(name)
             processor.value(field: name)
@@ -26,7 +25,6 @@ module Dradis
           end
         end
       end
-
 
       # ---------------------------------------------- Plugin Manager interface
 
@@ -51,7 +49,7 @@ module Dradis
 
       # Set the plugin's item template. This is used by the Plugins Manager
       # to force the plugin to use the new_template (provided by the user)
-      def set_template(args={})
+      def set_template(args = {})
         template = args[:template]
         content  = args[:content]
 
@@ -77,7 +75,7 @@ module Dradis
           # refresh cached version if modified since last read
           if template_mtime > @sources[template][:mtime]
             @template[template][:mtime] = template_mtime
-            @template[template][:content] = File.read( template_file )
+            @template[template][:content] = File.read(template_file)
           end
         else
           @sources[template] = {

--- a/spec/lib/dradis/plugins/template_service_spec.rb
+++ b/spec/lib/dradis/plugins/template_service_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+# To run, execute from Dradis main app folder:
+#   bin/rspec [dradis-plugins path]/spec/lib/dradis/plugins/template_service_spec.rb
+describe Dradis::Plugins::TemplateService do
+  describe '#process_template' do
+    let(:data) { double }
+    let(:plugin) { Dradis::Plugins::Nessus }
+    let(:template_service) do
+      Dradis::Plugins::TemplateService.new(plugin: plugin)
+    end
+
+    context 'liquid' do
+      before do
+        allow(data).to receive(:name).and_return('ReportHost')
+        allow(template_service).to receive(:template_source).and_return(
+          "{% if issue.evidence %}\n{% end if %}"
+        )
+      end
+
+      it 'does not parse the liquid data as fields' do
+        expect(template_service).to_not receive(:fields)
+
+        template_service.process_template(data: data)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Spec
If a user wants to include any Liquid content inside their Issue and/or Evidence via the Plugin Manager, it won't work due to the fact that the syntax for the Liquid and Plugin fields is exactly the same.
This situation limits Liquid usage for Issues and Evidence to manual-only and forces us to continue relying on VBA macros instead.

**Proposed solution**
Replace the regex in TemplateService with one that doesn't catch whitespace: 
```
/%(\S*?)%/
```