### PR TITLE
Include ProjectScoped in export/base_controller

### DIFF
--- a/app/controllers/dradis/plugins/export/base_controller.rb
+++ b/app/controllers/dradis/plugins/export/base_controller.rb
@@ -2,6 +2,7 @@ module Dradis
   module Plugins
     module Export
       class BaseController < Rails.application.config.dradis.base_export_controller_class_name.to_s.constantize
+        include ProjectScoped
         include UsageTracking if defined?(Dradis::Pro)
 
         before_action :validate_scope


### PR DESCRIPTION
Include ProjectScoped in export/base_controller so that track_Export can fetch project and associated records to build Ahoy event