### PR TITLE
Add preprovision initializer for app platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 v4.12.0 (XXXX 2024)
+  - Add preprovision initializer for app platforms
   - Update Dradis links in README
   - Fix the TypeError around the plugins template caching
 

--- a/lib/dradis/plugins/engine.rb
+++ b/lib/dradis/plugins/engine.rb
@@ -5,10 +5,33 @@ module Dradis
 
       config.dradis = ActiveSupport::OrderedOptions.new
 
-      initializer "dradis-plugins.set_configs" do |app|
+      initializer 'dradis-plugins.set_configs' do |app|
         options = app.config.dradis
         options.base_export_controller_class_name ||= 'AuthenticatedController'
         options.thor_helper_module ||= Dradis::Plugins::ThorHelper
+      end
+
+      # In App Platforms, assets:precompile is run before the DB is provisioned causing a
+      #   ActiveRecord::ConnectionNotEstablished: connection to server at "127.0.0.1",
+      #   port 5432 failed: Connection refused
+      #
+      # We run into this problem because dradis-plugins uses a :enabled/disabled DB
+      # setting for each integration to decide whether to load them or not.
+      #
+      # See:
+      #   https://devcenter.heroku.com/articles/rails-asset-pipeline
+      #
+      initializer 'dradis-plugins.preprovision-database' do
+        Rails.application.reloader.to_prepare do
+          # This is set by the App Platforms
+          if ENV['DATABASE_URL']
+            # DB isn't ready yet
+            if !(ActiveRecord::Base.connection rescue false)
+              # Empty the list of integrations.
+              Dradis::Plugins::class_variable_set('@@enabled_list', [])
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Please review [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/develop/CONTRIBUTING.md) and remove this line.

### Summary

In App Platforms, assets:precompile is run before the DB is provisioned causing a `ActiveRecord::ConnectionNotEstablished: connection to server at "127.0.0.1", port 5432 failed: Connection refused`

*Proposed Solution*
Manually set the enabled_list to empty the specific use case


### Testing Steps

Provide steps to test functionality, described in detail for someone not familiar with this part of the application / code base


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
- [ ] Added specs
