### PR TITLE
Replace blank field content with helpful message on template migration to mappings

### DIFF
--- a/lib/dradis/plugins/gem_version.rb
+++ b/lib/dradis/plugins/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
     module VERSION
       MAJOR = 4
       MINOR = 12
-      TINY  = 0
+      TINY  = 1
       PRE   = nil
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/lib/dradis/plugins/templates/migrate_templates.rb
+++ b/lib/dradis/plugins/templates/migrate_templates.rb
@@ -72,7 +72,11 @@ module Dradis
               source_field = field_content.match(LEGACY_FIELDS_REGEX)
               source_field = source_field ? source_field[1] : 'Custom Text'
 
-              updated_content = update_syntax(field_content)
+              updated_content = if field_content.empty?
+                "No content defined for this field in Mappings Manager"
+              else
+                update_syntax(field_content)
+              end
 
               mapping.mapping_fields.find_or_create_by!(
                 source_field: source_field,

--- a/lib/dradis/plugins/templates/migrate_templates.rb
+++ b/lib/dradis/plugins/templates/migrate_templates.rb
@@ -73,7 +73,7 @@ module Dradis
               source_field = source_field ? source_field[1] : 'Custom Text'
 
               updated_content = if field_content.empty?
-                "!NO_CONTENT_DEFINED_FOR_THIS_FIELD_IN_MAPPINGS_MANAGER!"
+                '!NO_CONTENT_DEFINED_FOR_THIS_FIELD_IN_MAPPINGS_MANAGER!'
               else
                 update_syntax(field_content)
               end

--- a/lib/dradis/plugins/templates/migrate_templates.rb
+++ b/lib/dradis/plugins/templates/migrate_templates.rb
@@ -73,7 +73,7 @@ module Dradis
               source_field = source_field ? source_field[1] : 'Custom Text'
 
               updated_content = if field_content.empty?
-                "No content defined for this field in Mappings Manager"
+                "!NO_CONTENT_DEFINED_FOR_THIS_FIELD_IN_MAPPINGS_MANAGER!"
               else
                 update_syntax(field_content)
               end


### PR DESCRIPTION
### Summary
We need to allow migration of blank fields from .template files to mapping fields. Since blank mapping field content is not permitted, we are replacing the blank content with a message

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
- [ ] Added specs
