### PR TITLE
Do not migrate templates to mappings unless mappings table has been created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.12.2 (June 2024)
+  - Do not migrate templates to mappings unless mappings table has been created
+
 v4.12.0 (May 2024)
   - Update Dradis links in README
   - Fix the TypeError around the plugins template caching

--- a/lib/dradis/plugins/gem_version.rb
+++ b/lib/dradis/plugins/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
     module VERSION
       MAJOR = 4
       MINOR = 12
-      TINY  = 1
+      TINY  = 2
       PRE   = nil
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/lib/dradis/plugins/templates/migrate_templates.rb
+++ b/lib/dradis/plugins/templates/migrate_templates.rb
@@ -27,6 +27,7 @@ module Dradis
 
         module ClassMethods
           def migrate_templates_to_mappings(args = {})
+            return unless ::Mapping.table_exists?
             # return if the integration doesn't provide any templates ex. projects, cve
             return unless paths['dradis/templates'].existent.any?
             @integration_name = plugin_name.to_s


### PR DESCRIPTION
### Summary
Return early in `migrate_templates_to_mappings` if the mappings table doesn't exist yet. 
This causes an issue when migrating from an older OVA to a new OVA when the mappings table has not yet been created and the initializer tries to run this method

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
