### PR TITLE
Add spec macros

### DIFF
--- a/spec/support/spec_macros.rb
+++ b/spec/support/spec_macros.rb
@@ -1,0 +1,26 @@
+module Dradis::Plugins::SpecMacros
+  extend ActiveSupport::Concern
+
+  def stub_content_service
+    @content_service = Dradis::Plugins::ContentService::Base.new(
+      logger: Logger.new(STDOUT),
+      plugin: Dradis::Plugins::Nexpose
+    )
+
+    # Stub content_service methods
+    # They return their argument hashes as objects mimicking
+    # nodes, issues, etc
+    allow(@content_service).to receive(:create_node) do |args|
+      OpenStruct.new(args)
+    end
+    allow(@content_service).to receive(:create_note) do |args|
+      OpenStruct.new(args)
+    end
+    allow(@content_service).to receive(:create_issue) do |args|
+      OpenStruct.new(args)
+    end
+    allow(@content_service).to receive(:create_evidence) do |args|
+      OpenStruct.new(args)
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Add spec macros so that spec setup methods can be used in integration specs
Add `stub_content_service` method to spec macros


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- ~[ ] Added a CHANGELOG entry~
- ~[ ] Added specs~
