### PR TITLE
Guard Configuration check to fix error on db:prepare when engines are loaded

### DIFF
--- a/lib/dradis/plugins/settings/adapters/db.rb
+++ b/lib/dradis/plugins/settings/adapters/db.rb
@@ -9,11 +9,11 @@ module Dradis::Plugins::Settings::Adapters
     end
 
     def exists?(key)
-      Configuration.exists?(name: namespaced_key(key))
+      db_ready && Configuration.exists?(name: namespaced_key(key))
     end
 
     def read(key)
-      Configuration.find_by(name: namespaced_key(key))&.value
+      db_ready && Configuration.find_by(name: namespaced_key(key))&.value
     end
 
     def write(key, value)
@@ -25,6 +25,10 @@ module Dradis::Plugins::Settings::Adapters
 
     def namespaced_key(key)
       [@namespace, key.to_s.underscore].join(':')
+    end
+
+    def db_ready
+      (ActiveRecord::Base.connection rescue false) && Configuration.table_exists?
     end
   end
 end

--- a/lib/dradis/plugins/settings/adapters/db.rb
+++ b/lib/dradis/plugins/settings/adapters/db.rb
@@ -9,11 +9,11 @@ module Dradis::Plugins::Settings::Adapters
     end
 
     def exists?(key)
-      db_ready && Configuration.exists?(name: namespaced_key(key))
+      db_ready? && Configuration.exists?(name: namespaced_key(key))
     end
 
     def read(key)
-      db_ready && Configuration.find_by(name: namespaced_key(key))&.value
+      db_ready? && Configuration.find_by(name: namespaced_key(key))&.value
     end
 
     def write(key, value)
@@ -27,7 +27,7 @@ module Dradis::Plugins::Settings::Adapters
       [@namespace, key.to_s.underscore].join(':')
     end
 
-    def db_ready
+    def db_ready?
       (ActiveRecord::Base.connection rescue false) && Configuration.table_exists?
     end
   end


### PR DESCRIPTION
### Summary

Having an engine in the main app Gemfile.plugins causes `db:prepare` to fail since we are checking if `engine.enabled?` when the engine is loaded. When the db doesn't exist yet, this check raises an error

This fix ensures that the db is ready before checking whether the engine is enabled

### Testing Steps

1. In the main app, drop your db `./bin/rails db:drop`
2. Point your Gemfile.plugins to your local repo for any integration ex `gem 'integration', path: ../<integration_name>`
3. Run `./bin/rails db:prepare` and assert that it succeeds


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [ ] Added a CHANGELOG entry~
~- [ ] Added specs~
