### PR TITLE
Update ActiveRecord::Base.connection to include `verify!` for Rails 7.2 compatibility

### DIFF
--- a/lib/dradis/plugins/settings/adapters/db.rb
+++ b/lib/dradis/plugins/settings/adapters/db.rb
@@ -28,7 +28,7 @@ module Dradis::Plugins::Settings::Adapters
     end
 
     def db_ready?
-      (ActiveRecord::Base.connection rescue false) && Configuration.table_exists?
+      (ActiveRecord::Base.connection.verify! rescue false) && Configuration.table_exists?
     end
   end
 end


### PR DESCRIPTION
### Summary
Call ActiveRecord::Base.connection.verify! instead of just ActiveRecord::Base.connection since the former no longer raises an error when the db hasn't been created yet

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
- [ ] Added specs
