### PR TITLE
Accept 'state' command line option from uploader thor tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 v4.16.0 (Month 2025)
   - Enable audit tracking for persistent permissions changes
   - Default to draft state on tool upload
+  - Accept 'state' command line option from uploader thor tasks
 
 v4.15.0 (December 2024)
   - No changes

--- a/lib/dradis/plugins/thor_helper.rb
+++ b/lib/dradis/plugins/thor_helper.rb
@@ -9,20 +9,28 @@ module Dradis
       end
 
       def task_options
-        @task_options ||= { logger: logger, state: :draft }
+        @task_options ||= { logger: logger, state: detect_state }
       end
 
       def logger
         @logger ||= default_logger
       end
 
-
       private
+
       def default_logger
         STDOUT.sync   = true
         logger        = Logger.new(STDOUT)
         logger.level  = Logger::DEBUG
         logger
+      end
+
+      def detect_state
+        if options.state && Upload::Importer::VALID_STATES.include?(options.state)
+          options.state.to_sym
+        else
+          :draft
+        end
       end
     end
   end

--- a/lib/dradis/plugins/upload/importer.rb
+++ b/lib/dradis/plugins/upload/importer.rb
@@ -5,6 +5,9 @@ module Dradis
   module Plugins
     module Upload
       class Importer
+
+        VALID_STATES = %w[draft published ready_for_review].freeze
+
         attr_accessor(
           :content_service,
           :default_user_id,


### PR DESCRIPTION
### Summary
Allow users could to pass a `state` argument when uploading tool output via the command line


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [ ] Added specs
