### PR TITLE
Add `Exportable` concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.X.X (Month 2025)
+  - Add Exportable concern to house shared report export logic from Export::BaseController
+
 v4.16.0 (May 2025)
   - Enable audit tracking for persistent permissions changes
   - Default to draft state on tool upload

--- a/app/controllers/concerns/dradis/plugins/exportable.rb
+++ b/app/controllers/concerns/dradis/plugins/exportable.rb
@@ -1,0 +1,38 @@
+module Dradis
+  module Plugins
+    module Exportable
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :set_exporter, only: [:create]
+        before_action :validate_scope, only: [:create]
+        before_action :validate_template, only: [:create]
+      end
+
+      private
+
+      def validate_template
+        @template_file =
+          File.expand_path(File.join(templates_dir, export_params[:template]))
+
+        unless @template_file.starts_with?(templates_dir) && File.exists?(@template_file)
+          raise 'Something fishy is going on...'
+        end
+      end
+
+      def validate_scope
+        unless Dradis::Plugins::ContentService::Base::VALID_SCOPES.include?(export_params[:scope])
+          raise 'Something fishy is going on...'
+        end
+      end
+
+      def set_exporter
+        raise NotImplementedError
+      end
+
+      def templates_dir
+        @templates_dir ||= File.join(::Configuration::paths_templates_reports, @exporter)
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/dradis/plugins/exportable.rb
+++ b/app/controllers/concerns/dradis/plugins/exportable.rb
@@ -11,13 +11,12 @@ module Dradis
 
       private
 
-      def validate_template
-        @template_file =
-          File.expand_path(File.join(templates_dir, export_params[:template]))
+      def set_exporter
+        raise NotImplementedError
+      end
 
-        unless @template_file.starts_with?(templates_dir) && File.exists?(@template_file)
-          raise 'Something fishy is going on...'
-        end
+      def templates_dir
+        @templates_dir ||= File.join(::Configuration::paths_templates_reports, @exporter)
       end
 
       def validate_scope
@@ -26,12 +25,13 @@ module Dradis
         end
       end
 
-      def set_exporter
-        raise NotImplementedError
-      end
+      def validate_template
+        @template_file =
+          File.expand_path(File.join(templates_dir, export_params[:template]))
 
-      def templates_dir
-        @templates_dir ||= File.join(::Configuration::paths_templates_reports, @exporter)
+        unless @template_file.starts_with?(templates_dir) && File.exists?(@template_file)
+          raise 'Something fishy is going on...'
+        end
       end
     end
   end

--- a/app/controllers/concerns/dradis/plugins/exportable.rb
+++ b/app/controllers/concerns/dradis/plugins/exportable.rb
@@ -26,7 +26,7 @@ module Dradis
       def validate_scope
         unless Dradis::Plugins::ContentService::Base::VALID_SCOPES.include?(export_params[:scope])
           if is_api?
-            render_json_error(Exception.new('Something fishy is going ontress...'), 422)
+            render_json_error(Exception.new('Something fishy is going on...'), 422)
           else
             raise 'Something fishy is going on...'
           end
@@ -45,5 +45,6 @@ module Dradis
           end
         end
       end
+    end
   end
 end

--- a/app/controllers/concerns/dradis/plugins/exportable.rb
+++ b/app/controllers/concerns/dradis/plugins/exportable.rb
@@ -25,7 +25,6 @@ module Dradis
 
       def validate_scope
         unless Dradis::Plugins::ContentService::Base::VALID_SCOPES.include?(export_params[:scope])
-          byebug
           if is_api?
             render_json_error(Exception.new('Something fishy is going ontress...'), 422)
           else

--- a/app/controllers/concerns/dradis/plugins/exportable.rb
+++ b/app/controllers/concerns/dradis/plugins/exportable.rb
@@ -11,6 +11,10 @@ module Dradis
 
       private
 
+      def is_api?
+        controller_path.include?('api')
+      end
+
       def set_exporter
         raise NotImplementedError
       end
@@ -21,7 +25,12 @@ module Dradis
 
       def validate_scope
         unless Dradis::Plugins::ContentService::Base::VALID_SCOPES.include?(export_params[:scope])
-          raise 'Something fishy is going on...'
+          byebug
+          if is_api?
+            render_json_error(Exception.new('Something fishy is going ontress...'), 422)
+          else
+            raise 'Something fishy is going on...'
+          end
         end
       end
 
@@ -30,9 +39,12 @@ module Dradis
           File.expand_path(File.join(templates_dir, export_params[:template]))
 
         unless @template_file.starts_with?(templates_dir) && File.exists?(@template_file)
-          raise 'Something fishy is going on...'
+          if is_api?
+            render_json_error(Exception.new('Something fishy is going on...'), 422)
+          else
+            raise 'Something fishy is going on...'
+          end
         end
       end
-    end
   end
 end

--- a/app/controllers/dradis/plugins/export/base_controller.rb
+++ b/app/controllers/dradis/plugins/export/base_controller.rb
@@ -2,11 +2,10 @@ module Dradis
   module Plugins
     module Export
       class BaseController < Rails.application.config.dradis.base_export_controller_class_name.to_s.constantize
+        include Exportable
         include ProjectScoped
         include UsageTracking if defined?(Dradis::Pro)
 
-        before_action :validate_scope
-        before_action :validate_template
         after_action :track_export, if: -> { defined?(Dradis::Pro) }
 
         protected
@@ -15,35 +14,16 @@ module Dradis
           params.permit(:project_id, :scope, :template)
         end
 
-        def validate_template
-          @template_file =
-            File.expand_path(File.join(templates_dir, export_params[:template]))
-
-          unless @template_file.starts_with?(templates_dir) && File.exists?(@template_file)
-            raise 'Something fishy is going on...'
-          end
-        end
-
-        def validate_scope
-          unless Dradis::Plugins::ContentService::Base::VALID_SCOPES.include?(export_params[:scope])
-            raise 'Something fishy is going on...'
-          end
-        end
-
         private
 
-        def engine_name
-          "#{self.class.to_s.deconstantize}::Engine".constantize.plugin_name.to_s
-        end
-
-        def templates_dir
-          @templates_dir ||= File.join(::Configuration::paths_templates_reports, engine_name)
+        def set_exporter
+          @exporter = "#{self.class.to_s.deconstantize}::Engine".constantize.plugin_name.to_s
         end
 
         def track_export
           project = Project.includes(:evidence, :nodes).find(current_project.id)
           track_usage('report.exported', {
-            exporter: engine_name,
+            exporter: @exporter,
             issue_count: project.issues.size,
             evidence_count: project.evidence.size,
             node_count: project.nodes.in_tree.size


### PR DESCRIPTION
### Summary

Moved shared export functionality to concern so it can be used by multiple export-related controllers including `export/base_controller` and the Dradis Pro API


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
- [ ] Added specs
