### PR TITLE
Don't track `report.exported` event in #show action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 v4.X.X (Month 2025)
   - Add Exportable concern to house shared report export logic from Export::BaseController
+  - Only track report export when report is created
 
 v4.16.0 (May 2025)
   - Enable audit tracking for persistent permissions changes

--- a/app/controllers/dradis/plugins/export/base_controller.rb
+++ b/app/controllers/dradis/plugins/export/base_controller.rb
@@ -6,7 +6,7 @@ module Dradis
         include ProjectScoped
         include UsageTracking if defined?(Dradis::Pro)
 
-        after_action :track_export, if: -> { defined?(Dradis::Pro) }, only: [:create]
+        after_action :track_export, only: [:create], if: -> { defined?(Dradis::Pro) }
 
         protected
 

--- a/app/controllers/dradis/plugins/export/base_controller.rb
+++ b/app/controllers/dradis/plugins/export/base_controller.rb
@@ -6,7 +6,7 @@ module Dradis
         include ProjectScoped
         include UsageTracking if defined?(Dradis::Pro)
 
-        after_action :track_export, if: -> { defined?(Dradis::Pro) }
+        after_action :track_export, if: -> { defined?(Dradis::Pro) }, only: [:create]
 
         protected
 


### PR DESCRIPTION
### Summary

Currently we're tracking the 'report.exported' ahoy event in the #show action of any controller that extends `Export::BaseController`

We don't need to double track, and tracking this on #create is enough

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
