### PR TITLE
Update deprecated `File.exists?` to `File.exist?` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+vX.X.X (Month 2025)
+  - Update File.exists? calls for ruby upgrade
+
 v4.17.0 (July 2025)
   - Add Exportable concern to house shared report export logic from Export::BaseController
   - Only track report export when report is created

--- a/app/controllers/concerns/dradis/plugins/exportable.rb
+++ b/app/controllers/concerns/dradis/plugins/exportable.rb
@@ -37,7 +37,7 @@ module Dradis
         @template_file =
           File.expand_path(File.join(templates_dir, export_params[:template]))
 
-        unless @template_file.starts_with?(templates_dir) && File.exists?(@template_file)
+        unless @template_file.starts_with?(templates_dir) && File.exist?(@template_file)
           if is_api?
             render_json_error(Exception.new('Something fishy is going on...'), 422)
           else


### PR DESCRIPTION
### Summary

With the upgrade from Ruby 3.1.2 to 3.4.4 we need to update all references from `File.exists?` to `File.exist?`

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
~- [ ] Added specs~