### PR TITLE
Only write `Configuration` setting if db is ready

### DIFF
--- a/lib/dradis/plugins/settings/adapters/db.rb
+++ b/lib/dradis/plugins/settings/adapters/db.rb
@@ -17,6 +17,7 @@ module Dradis::Plugins::Settings::Adapters
     end
 
     def write(key, value)
+      return unless db_ready?
       db_setting = Configuration.find_or_create_by(name: namespaced_key(key))
       db_setting.update_attribute(:value, value)
     end


### PR DESCRIPTION
### Summary

Currently we call `write(k, v)` when updating an integration's settings. This throws an error if the db isn't ready yet, so we need to check before trying to update the `Configuration` value

### Check List

- [ ] Added a CHANGELOG entry
- [ ] Added specs
