### PR TITLE
Store encrypted configuration in `config/credentials`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 vX.X.X (Month 2026)
   - Return false when checking Engine.enabled? if the db is not yet ready
+  - Store encrypted configuration under `config/credentials/`
+  - Only create a key file if `RAILS_MASTER_KEY` environment variable is not set
 
 v4.19.0 (November 2025)
   - Add state attribute to Result class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 vX.X.X (Month 2026)
   - Return false when checking Engine.enabled? if the db is not yet ready
   - Store encrypted configuration under `config/credentials/`
-  - Only create a key file if `RAILS_MASTER_KEY` environment variable is not set
 
 v4.19.0 (November 2025)
   - Add state attribute to Result class

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -33,12 +33,12 @@ module Dradis::Plugins::Settings::Adapters
 
     private
     def config_path
-      @config_path ||= Rails.root.join('config', 'shared', 'dradis-plugins.yml.enc')
+      @config_path ||= Rails.root.join('config', 'credentials', 'dradis-plugins.yml.enc')
     end
 
     def configuration
       @configuration ||= begin
-          create_key unless key_path.exist?
+          create_key unless key_path.exist? || ENV.fetch('RAILS_MASTER_KEY', nil)
 
           ActiveSupport::EncryptedConfiguration.new(
             config_path: config_path, key_path: key_path,
@@ -52,7 +52,7 @@ module Dradis::Plugins::Settings::Adapters
     end
 
     def key_path
-      @key_path ||= Rails.root.join('config', 'shared', 'dradis-plugins.key')
+      @key_path ||= Rails.root.join('config', 'credentials', 'dradis-plugins.key')
     end
   end
 end

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -43,7 +43,7 @@ module Dradis::Plugins::Settings::Adapters
 
           ActiveSupport::EncryptedConfiguration.new(
             config_path: config_path, key_path: key_path,
-            env_key: 'RAILS_MASTER_KEY', raise_if_missing_key: true
+            env_key: 'DRADIS_PLUGINS_KEY', raise_if_missing_key: true
           )
         end
     end

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -39,11 +39,10 @@ module Dradis::Plugins::Settings::Adapters
 
     def configuration
       @configuration ||= begin
-          create_key unless key_path.exist? || env.key?('DRADIS_PLUGINS_KEY')
+          create_key unless key_path.exist?
 
           ActiveSupport::EncryptedConfiguration.new(
-            config_path: config_path, key_path: key_path,
-            env_key: 'DRADIS_PLUGINS_KEY', raise_if_missing_key: true
+            config_path: config_path, key_path: key_path, raise_if_missing_key: true
           )
         end
     end

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -39,7 +39,7 @@ module Dradis::Plugins::Settings::Adapters
 
     def configuration
       @configuration ||= begin
-          create_key unless key_path.exist?
+          create_key unless key_path.exist? || env.key?('DRADIS_PLUGINS_KEY')
 
           ActiveSupport::EncryptedConfiguration.new(
             config_path: config_path, key_path: key_path,

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -32,13 +32,14 @@ module Dradis::Plugins::Settings::Adapters
     end
 
     private
+
     def config_path
       @config_path ||= Rails.root.join('config', 'credentials', 'dradis-plugins.yml.enc')
     end
 
     def configuration
       @configuration ||= begin
-          create_key unless key_path.exist? || ENV.fetch('RAILS_MASTER_KEY', nil)
+          create_key unless key_path.exist?
 
           ActiveSupport::EncryptedConfiguration.new(
             config_path: config_path, key_path: key_path,


### PR DESCRIPTION
### Summary

- Move `dradis-plugins.yml.enc` and `dradis-plugins.key` to config/credentials instead of storing them in config/shared, as the latter is an outdated storage path from VM deployments


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
~- [ ] Added specs~
