### PR TITLE
Release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-vX.X.X (Month 2026)
+v5.0.0 (March 2026)
   - Return false when checking Engine.enabled? if the db is not yet ready
   - Store encrypted configuration under `config/credentials/`
 

--- a/lib/dradis/plugins/gem_version.rb
+++ b/lib/dradis/plugins/gem_version.rb
@@ -6,8 +6,8 @@ module Dradis
     end
 
     module VERSION
-      MAJOR = 4
-      MINOR = 19
+      MAJOR = 5
+      MINOR = 0
       TINY = 0
       PRE   = nil
 

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -42,7 +42,7 @@ module Dradis::Plugins::Settings::Adapters
           create_key unless key_path.exist?
           # env_key is a no-op since we're always providing a key_path, but it is required by the initializer and we don't want to re-use RAILS_MASTER_KEY
           ActiveSupport::EncryptedConfiguration.new(
-            config_path: config_path, key_path: key_path, env_key: ENV["DRADIS_PLUGINS_KEY"], raise_if_missing_key: true
+            config_path: config_path, key_path: key_path, env_key: 'DRADIS_PLUGINS_KEY', raise_if_missing_key: true
           )
         end
     end

--- a/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
+++ b/lib/dradis/plugins/settings/adapters/encrypted_configuration.rb
@@ -40,9 +40,9 @@ module Dradis::Plugins::Settings::Adapters
     def configuration
       @configuration ||= begin
           create_key unless key_path.exist?
-
+          # env_key is a no-op since we're always providing a key_path, but it is required by the initializer and we don't want to re-use RAILS_MASTER_KEY
           ActiveSupport::EncryptedConfiguration.new(
-            config_path: config_path, key_path: key_path, raise_if_missing_key: true
+            config_path: config_path, key_path: key_path, env_key: ENV["DRADIS_PLUGINS_KEY"], raise_if_missing_key: true
           )
         end
     end


### PR DESCRIPTION
Release 5.0.0
Includes:
- Add `env_key` argument when creating `EncryptedConfiguration` but make it a no-op since we're always providing a key_path (it is required by the initializer). `DRADIS_PLUGINS_KEY` was chosen since it will not have a value and we don't want to re-use `RAILS_MASTER_KEY`.
