### PR TITLE
Add all_evidence to the content service, scoped by published/all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+[v#.#.#] ([month] [YYYY])
+  - Add `all_evidence` to the Evidence content service, scoping evidence by the export's published/all scope
+
 v5.3.0 (August 2026)
   - Add shared report template source resolution for mappings across ticketing integrations (Jira, DevOps, ServiceNow)
 

--- a/lib/dradis/plugins/content_service/evidence.rb
+++ b/lib/dradis/plugins/content_service/evidence.rb
@@ -2,6 +2,17 @@ module Dradis::Plugins::ContentService
   module Evidence
     extend ActiveSupport::Concern
 
+    def all_evidence
+      case scope
+      when :all
+        project.evidence
+      when :published
+        project.evidence.published
+      else
+        raise 'Unsupported scope!'
+      end
+    end
+
     def create_evidence(args = {})
       content = args.fetch(:content, default_evidence_content)
       node    = args.fetch(:node, default_node_parent)

--- a/spec/lib/dradis/plugins/content_service/evidence_spec.rb
+++ b/spec/lib/dradis/plugins/content_service/evidence_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+# To run, execute from Dradis Pro main app folder:
+#   bin/rspec [dradis-plugins path]/spec/lib/dradis/plugins/content_service/evidence_spec.rb
+
+describe 'Evidence content service' do
+  let(:plugin) { Dradis::Plugins::Nessus }
+  let(:plugin_id) { '111' }
+  let(:project) { create(:project) }
+  let(:node) { create(:node, project: project) }
+  let(:issue) { create(:issue, node: project.issue_library) }
+  let(:service) do
+    Dradis::Plugins::ContentService::Base.new(
+      plugin: plugin,
+      logger: Rails.logger,
+      project: project
+    )
+  end
+
+  describe '#all_evidence' do
+    before do
+      @draft_evidence = create_list(:evidence, 10, node: node, issue: issue, state: :draft)
+      @review_evidence = create_list(:evidence, 10, node: node, issue: issue, state: :ready_for_review)
+      @published_evidence = create_list(:evidence, 10, node: node, issue: issue, state: :published)
+    end
+
+    it 'returns only the published evidence' do
+      expect(service.all_evidence.to_a).to match_array(@published_evidence)
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Adds `Dradis::Plugins::ContentService::Evidence#all_evidence`, mirroring the existing `Issues#all_issues` and `ContentBlocks#all_content_blocks`:

```ruby
def all_evidence
  case scope
  when :all
    project.evidence
  when :published
    project.evidence.published
  else
    raise 'Unsupported scope!'
  end
end
```

This lets export plugins fetch Evidence already scoped to the export's `:published`/`:all` scope, the same way they already do for Issues and Content Blocks, instead of re-querying `node.evidence`/`issue.evidence` themselves inside export processors.

Needed by the Pro-side Word export change that only includes published Evidence in exported reports (Evidence now has an independent `published`/`draft`/`ready_for_review` review state, added in dradis-ce/dradis-pro branch `qa/add-evidence-review-state`). Requires `Evidence#published` (a Rails enum scope) to exist on the host app's `Evidence` model, which that branch adds.

### Testing Steps

From the Dradis Pro app directory, with this gem checked out at a sibling path, temporarily point the Gemfile at this branch/path and run:

```
bin/rspec [dradis-plugins path]/spec/lib/dradis/plugins/content_service/evidence_spec.rb
```

Assert all examples pass, confirming `all_evidence` returns only published evidence by default and all evidence when scope is `:all`.

### Other Information

Once merged, this needs a version bump + gem release, and the Pro-side PR (dradis-pro#2926) needs its temporary local path override in the Gemfile switched to the released version.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Added specs